### PR TITLE
Ruby: Fix error message in handle_content

### DIFF
--- a/lib/keight.rb
+++ b/lib/keight.rb
@@ -839,7 +839,7 @@ module K8
       #; [!apwh4] else...
       else
         #; [!wmgnr] raises K8::UnknownContentError.
-        raise UnknownContentError.new("Unknown content: class={content.class}, content=#{content.inspect}")
+        raise UnknownContentError.new("Unknown content: class=#{content.class}, content=#{content.inspect}")
       end
     end
 


### PR DESCRIPTION
I've been hitting this message a lot lately, and only now do I realize it's missing an important character that would shed a *lot* more light on things...